### PR TITLE
Add Number.toDstring and fix a bug with the constructor of dutils.math.number.Number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,14 @@
 
 -  dutils.math.def contains the definitions for the template mathematical type:  Mtype, and for the wrappers for the function and operator lists.
 
--  dutils.math.number contains the definition of the Number type, which is currently incomplete and undocumented.
-   The Number type currently supports four operations: +, -, *, and /.
+-  dutils.math.number contains the definition of the Number type, which is currently incomplete.
+   The Number type currently supports four operations: +, -, *, and /, and the ability to serialize to a string via toDstring.
 
--  dutils.math.core currently only supports registering, validating, and unregistering a function.
+-  dutils.math.core currently only supports registering and validating a function.
 
 ## REMOVED
 
-### dutils.math
-
--  Anything that existed before in this subpackage has been deleted.
+- The entire library is getting a revamp, so I removed everything else.
 
 # Changelog for dutils v0.1.4
 ### dutils.math

--- a/source/dutils/math/core.d
+++ b/source/dutils/math/core.d
@@ -21,12 +21,12 @@ public import dutils.math.def;
 
 version(DLL)
 {
-	mixin("export:");
+    mixin("export:");
 }
 
 else
 {
-	mixin("public:");
+    mixin("public:");
 }
 
 /********************************************************
@@ -52,6 +52,16 @@ bool registerFunction(in dstring name, in dstring func, in dstring def) @safe
     return ret;
 }
 
+///
+@safe unittest
+{
+    dstring func = "(Number)(Number)"d;
+    dstring def = "x1"d;
+    dstring name = "f"d;
+    assert(registerFunction(name, func, def));
+    assert(!registerFunction(name, func, def)); //No registering an already-existing function.
+}
+
 /**************************************************
  * Removes a function provided that it exists.
  *
@@ -72,6 +82,17 @@ bool removeFunction(in dstring name, in dstring func) @safe
         return true;
     }
     return false;
+}
+
+///
+@safe unittest
+{
+    dstring func = "(Number,Number)(Number)d";
+    dstring def = "x1*x2"d;
+    dstring name = "f"d;
+    assert(registerFunction(name, func, def)); //Valid, a different function under the same name is a different function in the library's eyes.
+    assert(removeFunction(name, func));
+    assert(!removeFunction(name, func)); //Cannot remove a non-existent function.
 }
 
 /*******************************************
@@ -204,7 +225,8 @@ bool validateFunction(in dstring func, in dstring def) @trusted
                                         static foreach(type2; typel.keys)
                                         {
                                             case typel[type2]:
-                                                mixin("bool b = opCheckCrap(" ~ type2 ~ "OperandList[0], " ~ type ~ "OperandList[0], currOp);");
+                                                mixin("bool b = opCheckCrap(" ~ type2 ~ "OperandList[0], "
+                                                ~ type ~ "OperandList[0], currOp);");
                                                 if(!b)
                                                     return false;
                                                 break Switch5;
@@ -215,7 +237,7 @@ bool validateFunction(in dstring func, in dstring def) @trusted
                         }
                     }
                     isOp = false;
-                    if(i == def.length-1)
+                    if(i == def.length - 1)
                     {
                         if(!def[i].isNumber && def[i] != d(')'))
                         {
@@ -260,7 +282,7 @@ bool validateFunction(in dstring func, in dstring def) @trusted
                             ++i;
                         }
                         while(def[i] != d(',') && def[i] != d(')')); //Just in case.
-                        bool a = (def[i] == d(')'));
+                        immutable bool a = (def[i] == d(')'));
                         ++i;
                         if(a && ((def[i] == d(',')) ^ (def[i] == d(')'))))
                             tempOps[$-1] ~= d(')'); //Fix bug about functions not working (I think I did, but I might be wrong).
@@ -382,7 +404,8 @@ bool validateFunction(in dstring func, in dstring def) @trusted
                                         static foreach(type2; typel.keys)
                                         {
                                             case typel[type2]:
-                                                mixin("bool b = opCheckCrap(" ~ type2 ~ "OperandList[0], " ~ type ~ "OperandList[0], currOp);");
+                                                mixin("bool b = opCheckCrap(" ~ type2 ~ "OperandList[0], "
+                                                ~ type ~ "OperandList[0], currOp);");
                                                 if(!b)
                                                     return false;
                                                 break Switch7;
@@ -396,7 +419,7 @@ bool validateFunction(in dstring func, in dstring def) @trusted
                     isOp = false;
                     break;
                 default:
-                    auto oldi = i;
+                    immutable oldi = i;
                     dchar[] tempstr = [];
                     do
                     {
@@ -497,7 +520,8 @@ bool validateFunction(in dstring func, in dstring def) @trusted
                                             static foreach(type2; typel.keys)
                                             {
                                                 case typel[type2]:
-                                                    mixin("bool b = opCheckCrap(" ~ type2 ~ "OperandList[0], " ~ type ~ "OperandList[0], currOp);");
+                                                    mixin("bool b = opCheckCrap(" ~ type2 ~ "OperandList[0], "
+                                                    ~ type ~ "OperandList[0], currOp);");
                                                     if(!b)
                                                         return false;
                                                     break Switch9;
@@ -532,13 +556,6 @@ bool validateFunction(in dstring func, in dstring def) @trusted
         while(i < def.length);
         if((isOp || !isOperand) || indentation != 0) //If there are no other syntax errors, ensure the following.
         {
-            debug
-            {
-                import std.stdio;
-                writeln(isOp);
-                writeln(isOperand);
-                writeln(indentation);
-            }
             return false;
         }
         return true;
@@ -568,7 +585,7 @@ bool validateFunction(in dstring func, in dstring def) @trusted
     def = "(x1"d;
     assert(!validateFunction(func, def));
     def = "(x1)"d;
-    assert(validateFunction(func, def)); //BUG: Traling characters are ignored.
+    assert(validateFunction(func, def));
     def = "x1)"d;
     assert(!validateFunction(func, def));
     def = "x1x2"d;
@@ -577,12 +594,21 @@ bool validateFunction(in dstring func, in dstring def) @trusted
     assert(!validateFunction(func, def));
 }
 
+/************************************
+ * Converts a char to a dchar.
+ *
+ * Params:
+ *     c =
+ *        The char to convert.
+ * Returns:
+ *     The char converted to a dchar.
+ */
 package dchar d(char c) pure @safe
 {
     return cast(dchar)c;
 }
 
-package void getParamsReturns(ref dstring[] input, immutable dstring func, ref size_t i) pure @safe //Get the types of the function parameters and the return types.
+private void getParamsReturns(ref dstring[] input, immutable dstring func, ref size_t i) pure @safe //Get the types of the function parameters and the return types.
 in
 {
     assert(func[i] == d('('), [cast(char)func[i]]);
@@ -607,7 +633,7 @@ do
 }
 
 //Function that checks whether using op currOp with type as its lhs and type2 as its rhs is valid.
-package bool opCheckCrap(W, X)(W type, X type2, dstring currOp)//Please god let W and X be inferred from the arguments please.
+private bool opCheckCrap(W, X)(W type, X type2, dstring currOp)//Please god let W and X be inferred from the arguments please.
 {
     return type.applyOp(currOp, type2);
 }

--- a/source/dutils/math/def.d
+++ b/source/dutils/math/def.d
@@ -38,7 +38,7 @@ class Mtype(T)
     ///Apply an operation to an Mtype.
     abstract bool applyOp(W)(dstring op, Mtype!W rhs) pure  @safe;
     ///Apply an operation from the right side.
-    final bool applyOpRight(W)(dstring op, ref Mtype!W lhs) pure @safe
+    bool applyOpRight(W)(dstring op, ref Mtype!W lhs) pure @safe
     {
         return lhs.applyOp(op, this);
     }
@@ -52,7 +52,7 @@ class Mtype(T)
     {
         return T.stringof;
     }
-    package:
+    protected:
         T contained;
 }
 

--- a/source/dutils/math/number.d
+++ b/source/dutils/math/number.d
@@ -12,7 +12,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.*/
 /** Copyright: 2022, Ruby The Roobster*/
 /**Author: Ruby The Roobster, <rubytheroobster@yandex.com>*/
-/**Date: August 5, 2021*/
+/**Date: August 17, 2021*/
 /** License:  GPL-3.0**/
 
 ///Module for representing numbers.
@@ -28,27 +28,109 @@ version(Standard)
     public:
 }
 
+///Core dutils math library.
 public import dutils.math.core;
+///BigInt is a necessary type for our usage.
 public import std.bigint;
 
+///Class to represent Numbers in dutils.
 class Number : Mtype!NumberContainer
 {
-    this(NumberContainer num = NumberContainer(BigInt(0),BigInt(0),0))
+    /*****************************************************************
+     * Constructs a Number.
+     *
+     * Params:
+     *     num =
+     *         The value to contain within the Number.
+     */
+    this(in NumberContainer num = NumberContainer(BigInt(0),BigInt(0),0)) pure @safe nothrow @nogc
     {
-        this.contained = val;
+        this.contained = num;
     }
 
+    /***********************************************
+     * Represents a Number as a dstring.
+     *
+     * Returns:
+     *     The dstring representation of the Number.
+     */
     override dstring toDstring() const @property pure @safe
     {
-        return ""d; //Placeholder;
+        import std.format;
+        char[] temp = "".dup;
+        pragma(inline, true) void inFunc(in size_t i, in BigInt val) pure @safe
+        {
+            char[] temp2 = format("%s", val).dup;
+            if(this.contained.pow10 > 0)
+            {
+                temp ~= temp2;
+                temp.length += this.contained.pow10;
+                temp[$-1-this.contained.pow10 .. $] = '0';
+            }
+            else if(this.contained.pow10 < 0)
+            {
+                if(val < BigInt(0))
+                {
+                    temp2[0 .. $-1] = temp2[1 .. $].dup;
+                    --temp2.length;
+                }
+                temp ~= temp2;
+                if(-this.contained.pow10 > temp2.length)
+                {
+                    temp.length -= (this.contained.pow10);
+                    temp[i] = '.';
+                    temp[i+1 .. i-(this.contained.pow10+temp2.length)] = '0';
+                    temp[i-(this.contained.pow10 + temp2.length) .. $] = temp2.dup;
+                }
+                else
+                {
+                    temp2 = temp[i-1-this.contained.pow10 .. $].dup;
+                    temp[i-1-this.contained.pow10] = '.';
+                    ++temp.length;
+                    temp[i-this.contained.pow10 .. $] = temp2.dup;
+                }
+            }
+        }
+        inFunc(0, this.contained.val);
+        if(this.contained.ival < 0)
+            temp ~= '-';
+        else
+            temp ~= '+';
+        inFunc(temp.length, this.contained.ival);
+        temp ~= 'i';
+        dchar[] temp2;
+        foreach(c; temp)
+        {
+            ++temp2.length;
+            temp2[$-1] = d(c);
+        }
+        return temp2.idup;
     }
 
+    /***********************************
+     * Serializes a dstring to a Number.
+     *
+     * Params:
+     *     from =
+     *         The dstring to serialize.
+     */
     override void fromDstring(dstring from) pure @safe
     {
         //Placeholder
     }
 
-    bool applyOp(W)(dstring op, Mtype!W rhs) pure @safe
+    /*************************************************
+     * Applies an operator to a Number given the rhs.
+     *
+     * Params:
+     *     op =
+     *         The operator to apply.
+     *     rhs =
+     *         The right hand side of the expression.
+     * Returns:
+     *     Whether the operation was succesful or not.
+     */
+    bool applyOp(W)(in dstring op, in Mtype!W rhs) pure @safe
     in
     {
         assert(is(W == NumberContainer));
@@ -61,17 +143,49 @@ class Number : Mtype!NumberContainer
             static foreach(o; ["+"d, "-"d, "*"d, "/"d, "^^"d])
             {
                 case o:
-                    mixin("this.contained.opOpAssign!\""d ~ o ~ "\"(rhs.contained);"d);
+                    mixin("this.contained "d ~ o ~ "= rhs.contained;"d);
                     break Switch;
             }
         }
         return true; //We assume that the contract hasn't been violated.
     }
 
+    /*************************************************
+     * The result of applying an operator to a Number.
+     *
+     * Params:
+     *     op =
+     *         The operator to apply.
+     *     rhs =
+     *         THe right hand side of the expression.
+     * Returns:
+     *     The result of the expression.
+     */
+    Number applyOpResult(W)(dstring op, Mtype!W rhs) pure @safe
+    {
+        Number temp = new Number();
+        temp.val = this.val;
+        temp.applyOp!W(op, rhs);
+        return new Number(temp.val);
+    }
 }
 
+///Type that is contained by Number.
 struct NumberContainer
 {
+    /**********************************************************************************
+     * Constructs a NumberContainer.
+     *
+     * Params:
+     *     val =
+     *         The real part of the NumberContainer, expressed as a BigInt.
+     *     ival =
+     *         The imaginary part of the NumberContainer, expressed as a BigInt.
+     *     pow10 =
+     *         The power of 10 to multiply both parts by.
+     *     precision =
+     *         The digits of precision to use in divison and exponentiation operations.
+     */
     this(BigInt val, BigInt ival = 0, long pow10 = 0, ulong precision = 18) pure @safe nothrow @nogc
     {
         this.val = val;
@@ -80,6 +194,28 @@ struct NumberContainer
         this.precision = precision;
     }
 
+    /*******************************************************
+     * Assigns a NumberContainer to another NumberContainer.
+     *
+     * Params:
+     *     rhs =
+     *         The NumberContainer to assign.
+     */
+    void opAssign(in NumberContainer rhs) pure @safe nothrow @nogc
+    {
+        this.pow10 = rhs.pow10;
+        this.val = rhs.val;
+        this.ival = rhs.ival;
+        this.precision = rhs.precision;
+    }
+
+    /*************************************************
+     * Overloading of the binary assignment operators.
+     *
+     * Params:
+     *     rhs =
+     *         The right hand side of the expression.
+     */
     void opOpAssign(string op)(NumberContainer rhs) pure @safe
     {
         import std.algorithm : max;
@@ -92,7 +228,7 @@ struct NumberContainer
             auto istore = NumberContainer(cast(BigInt)0, cast(BigInt)0);
             long count = 0;
             ubyte count2 = 9;
-            bool sign = (rhs.ival < 0); //Fix the infinite loop that occurs for negative values of rhs.ival.
+            immutable bool sign = (rhs.ival < 0); //Fix the infinite loop that occurs for negative values of rhs.ival.
             if(sign)
                 rhs.ival *= -1;
             for(ulong i = 0; i < this.precision; ++i) //Real part
@@ -168,7 +304,7 @@ struct NumberContainer
         }
         else static if(op == "*")
         {
-            auto temp = this.val;
+            immutable temp = this.val;
             this.val *= rhs.val;
             this.val -= (this.ival * rhs.ival);
             this.ival = (this.ival * rhs.val);
@@ -193,27 +329,46 @@ struct NumberContainer
         }
     }
 
+    /*******************************************************
+     * Overloading of the binary operators.
+     *
+     * Params:
+     *     rhs =
+     *         The right hand side of the expression.
+     * Returns:
+     *     The result of the expression.
+     */
     NumberContainer opBinary(string op)(NumberContainer rhs) pure @safe
     {
         NumberContainer ret = this;
         mixin("ret " ~ op ~ " rhs;");
         return ret;
     }
-    package:
+
+    bool opEquals(in NumberContainer rhs) pure @safe nothrow const @nogc
+    {
+        return ((this.val == rhs.val) && (this.ival == rhs.ival))
+        && ((this.pow10 == rhs.pow10) && (this.precision == rhs.precision));
+    }
+    private:
         BigInt val;
         BigInt ival;
-        long pow10;
+        static if(is(size_t == ulong))
+            long pow10;
+        else static if(is(size_t == uint))
+            int pow10;
         ulong precision;
 }
 
 ///
-@safe unittest {
+pure @safe unittest {
     BigInt a = 1;
-    BigInt b = -1;
-    long c = 0;
-    NumberContainer e = NumberContainer(a,b,c);
+    immutable BigInt b = -1;
+    immutable long c = 0;
+    Number e = new Number(NumberContainer(a,b,c));
     a = 2;
-    NumberContainer f = NumberContainer(a,b,c);
-    e /= f;
-    assert((e.val == 6 && e.pow10 == -1) && e.ival == -2);
+    Number f = new Number(NumberContainer(a,b,c));
+    e.applyOp("/", f);
+    assert(e.val == NumberContainer(BigInt(6), BigInt(-2), -1L));
+    assert(e.toDstring == ".6-.2i"d, cast(string)e.toDstring);
 }

--- a/source/dutils/math/package.d
+++ b/source/dutils/math/package.d
@@ -19,12 +19,14 @@ module dutils.math;
 
 version(DLL)
 {
-	export:
+    export:
 }
 else
 {
-	public:
+    public:
 }
 
+/// Core part of the math library.
 import dutils.math.core;
+/// Implements complex numbers for the math library.
 import dutils.math.number;


### PR DESCRIPTION
The dutils math library's representation of a Number had a bug in which it would assign to this.contained NumberContainer(0,0,0,0).  This has been fixed.

In addition, Number.toDstring has been implemented, and is no longer a placeholder.